### PR TITLE
Pointing which courses of Full Stack Nanodegree are no longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ support hundreds of thousands of users.
   2. [Intro to HTML and CSS](https://www.udacity.com/course/intro-to-html-and-css--ud304)
   3. [Responsive Web Design Fundamentals](https://www.udacity.com/course/responsive-web-design-fundamentals--ud893)
   4. [Responsive Images](https://www.udacity.com/course/responsive-images--ud882)
-  5. [Intro to Backend](https://www.udacity.com/course/intro-to-backend--ud171)
+  5. [Intro to Backend](https://www.udacity.com/course/intro-to-backend--ud171)(No longer available)
   6. [Intro to Relational Databases](https://www.udacity.com/course/intro-to-relational-databases--ud197)
   7. [Full Stack Foundations](https://www.udacity.com/course/full-stack-foundations--ud088)
   8. [Authentication & Authorization: OAuth](https://www.udacity.com/course/authentication-authorization-oauth--ud330)
@@ -115,10 +115,10 @@ support hundreds of thousands of users.
   11. [Developing Scalable Apps in Python](https://www.udacity.com/course/developing-scalable-apps-in-python--ud858)
   12. [Linux Command Line Basics](https://www.udacity.com/course/linux-command-line-basics--ud595)
   13. [Configuring Linux Web Servers](https://www.udacity.com/course/configuring-linux-web-servers--ud299)
-  14. [Version Control with Git](https://www.udacity.com/course/version-control-with-git--ud123)
-  15. [GitHub and Collaboration](https://www.udacity.com/course/github-collaboration--ud456)
-  16. [Shell Workshop](https://www.udacity.com/course/shell-workshop--ud206)
-  17. [HTTP & Web Servers](https://www.udacity.com/course/http-web-servers--ud303)
+  14. [Version Control with Git](https://www.udacity.com/course/version-control-with-git--ud123)(No longer available)
+  15. [GitHub and Collaboration](https://www.udacity.com/course/github-collaboration--ud456)(No longer available)
+  16. [Shell Workshop](https://www.udacity.com/course/shell-workshop--ud206)(No longer available)
+  17. [HTTP & Web Servers](https://www.udacity.com/course/http-web-servers--ud303)(No longer available)
   18. [Designing RESTful APIs](https://www.udacity.com/course/designing-restful-apis--ud388)
 
 


### PR DESCRIPTION
Some of the courses of Full Stack Nanodegree were moved or deleted from Udacity. 